### PR TITLE
Update passport.js

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -110,14 +110,25 @@ module.exports = function(passport) {
             // if the user is logged in but has no local account...
             } else if ( !req.user.local.email ) {
                 // ...presumably they're trying to connect a local account
-                var user            = req.user;
-                user.local.email    = email;
-                user.local.password = user.generateHash(password);
-                user.save(function(err) {
+                // BUT let's check if the email used to connect a local account is being used by another user
+                User.findOne({ 'local.email' :  email }, function(err, user) {
                     if (err)
                         return done(err);
-                        
-                    return done(null, user);
+                    
+                    if (user) {
+                        return done(null, false, req.flash('loginMessage', 'That email is already taken.'));
+                        // Using 'loginMessage instead of signupMessage because it's used by /connect/local'
+                    } else {
+                        var user = req.user;
+                        user.local.email = email;
+                        user.local.password = user.generateHash(password);
+                        user.save(function (err) {
+                            if (err)
+                                return done(err);
+                            
+                            return done(null,user);
+                        });
+                    }
                 });
             } else {
                 // user is logged in and already has a local account. Ignore signup. (You should log out before trying to create a new account, user!)


### PR DESCRIPTION
Avoid connecting local account with an used email address when user is logged in but has no local account.
