### PR TITLE
passport-facebook - explicitly request the fields we want on successful auth.

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -147,6 +147,7 @@ module.exports = function(passport) {
         clientID        : configAuth.facebookAuth.clientID,
         clientSecret    : configAuth.facebookAuth.clientSecret,
         callbackURL     : configAuth.facebookAuth.callbackURL,
+        profileFields   : ['id', 'name', 'email'],
         passReqToCallback : true // allows us to pass in the req from our route (lets us check if a user is logged in or not)
 
     },


### PR DESCRIPTION
Code currently fails because facebook or `passport-facebook` does not return the `email` field by default.