### PR TITLE
Fix links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ If you would like to download the code and try it for yourself:
 
 ## The Tutorials
 
-- [Getting Started and Local Authentication](http://scotch.io/tutorials/javascript/easy-node-authentication-setup-and-local)
-- [Facebook](http://scotch.io/tutorials/javascript/easy-node-authentication-facebook)
-- [Twitter](http://scotch.io/tutorials/javascript/easy-node-authentication-twitter)
-- [Google](http://scotch.io/tutorials/javascript/easy-node-authentication-google)
-- [Linking All Accounts Together](http://scotch.io/tutorials/javascript/easy-node-authentication-linking-all-accounts-together)
+- [Getting Started and Local Authentication](http://scotch.io/tutorials/easy-node-authentication-setup-and-local)
+- [Facebook](http://scotch.io/tutorials/easy-node-authentication-facebook)
+- [Twitter](http://scotch.io/tutorials/easy-node-authentication-twitter)
+- [Google](http://scotch.io/tutorials/easy-node-authentication-google)
+- [Linking All Accounts Together](http://scotch.io/tutorials/easy-node-authentication-linking-all-accounts-together)


### PR DESCRIPTION
Links were broken, since the routes at scotch.io have changed. Removed the "/javascript" part. Now it's working again!